### PR TITLE
chore: add `prepare` npm-script to build the code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-http-promise",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "rimraf -rf dist && tsc -p tsconfig.json",
     "format": "prettier --write \"{lib}/**/*.ts\"",
     "lint": "eslint 'lib/**/*.ts' --fix",
+    "prepare": "npm run build",
     "prepublish:npm": "npm run build",
     "publish:npm": "npm publish --access public",
     "publish:beta": "npm publish --access public --tag beta",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-http-promise",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "keywords": [
     "nestjs",
     "http",


### PR DESCRIPTION
With the [`prepare`](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) life cycle script users of your package could fork your repo and use their fork instead easily

### before

```bash
$ npm i benhason1/nestjs-http-promise
$ ll node_modules/nestjs-http-promise
total 48
drwxrwxr-x  5 micael micael 4096 mai 11 19:28 ./
drwxrwxr-x 17 micael micael 4096 mai 11 19:28 ../
-rw-rw-r--  1 micael micael   12 mai 11 19:28 .eslintignore
-rw-rw-r--  1 micael micael  725 mai 11 19:28 .eslintrc.js
drwxrwxr-x  4 micael micael 4096 mai 11 19:28 .github/
drwxrwxr-x  3 micael micael 4096 mai 11 19:28 lib/
-rw-rw-r--  1 micael micael 1066 mai 11 19:28 LICENSE
drwxrwxr-x  3 micael micael 4096 mai 11 19:27 node_modules/
-rw-rw-r--  1 micael micael 1801 mai 11 19:28 package.json
-rw-rw-r--  1 micael micael   80 mai 11 19:28 .prettierrc
-rw-rw-r--  1 micael micael 3784 mai 11 19:28 README.md
-rw-rw-r--  1 micael micael  443 mai 11 19:28 tsconfig.json
```

see there's no `dist` directory in there thus we couldn't use this approach

### now

```bash
$ npm i benhason1/nestjs-http-promise
$ ll node_modules/nestjs-http-promise
total 52
drwxrwxr-x  6 micael micael 4096 mai 11 19:31 ./
drwxrwxr-x 17 micael micael 4096 mai 11 19:31 ../
drwxrwxr-x  3 micael micael 4096 mai 11 19:31 dist/
-rw-rw-r--  1 micael micael   12 mai 11 19:31 .eslintignore
-rw-rw-r--  1 micael micael  725 mai 11 19:31 .eslintrc.js
drwxrwxr-x  4 micael micael 4096 mai 11 19:31 .github/
drwxrwxr-x  3 micael micael 4096 mai 11 19:31 lib/
-rw-rw-r--  1 micael micael 1066 mai 11 19:31 LICENSE
drwxrwxr-x  3 micael micael 4096 mai 11 19:31 node_modules/
-rw-rw-r--  1 micael micael 1833 mai 11 19:31 package.json
-rw-rw-r--  1 micael micael   80 mai 11 19:31 .prettierrc
-rw-rw-r--  1 micael micael 3784 mai 11 19:31 README.md
-rw-rw-r--  1 micael micael  443 mai 11 19:31 tsconfig.json
```

now we can.